### PR TITLE
Fix/16 bit

### DIFF
--- a/Assets/Scripts/BLE/Commands/SubscribeToCharacteristic.cs
+++ b/Assets/Scripts/BLE/Commands/SubscribeToCharacteristic.cs
@@ -67,7 +67,7 @@ namespace Android.BLE.Commands
                 {
                     if (string.Equals(obj.Device, DeviceAddress) &&
                         string.Equals(obj.Service, DeviceAddress) &&
-                        string.Equals(obj.Characteristic, Characteristic.Get16BitUuid()))
+                        string.Equals(obj.Characteristic, Characteristic.Get8BitUuid()))
                     {
                         OnCharacteristicChanged?.Invoke(obj.GetByteMessage());
                     }

--- a/Assets/Scripts/BLE/Extension/UuidHelper.cs
+++ b/Assets/Scripts/BLE/Extension/UuidHelper.cs
@@ -2,7 +2,7 @@
 {
     public static class UuidHelper
     {
-        public static string Get16BitUuid(this string t)
+        public static string Get8BitUuid(this string t)
         {
             string firstPart = t.Split('-')[0];
             return firstPart.Substring(4, 4);


### PR DESCRIPTION
Fixed issue #9, where a custom 128-bit UUID wouldn't work, since the `_customGatt` property was not properly set in the constructor. Also changed the 16-bit handlers and extensions to 8-bit.