### PR TITLE
Replaced 8-bit to 4-bit

### DIFF
--- a/Assets/Scripts/BLE/Commands/SubscribeToCharacteristic.cs
+++ b/Assets/Scripts/BLE/Commands/SubscribeToCharacteristic.cs
@@ -67,7 +67,7 @@ namespace Android.BLE.Commands
                 {
                     if (string.Equals(obj.Device, DeviceAddress) &&
                         string.Equals(obj.Service, DeviceAddress) &&
-                        string.Equals(obj.Characteristic, Characteristic.Get8BitUuid()))
+                        string.Equals(obj.Characteristic, Characteristic.Get4BitUuid()))
                     {
                         OnCharacteristicChanged?.Invoke(obj.GetByteMessage());
                     }

--- a/Assets/Scripts/BLE/Extension/UuidHelper.cs
+++ b/Assets/Scripts/BLE/Extension/UuidHelper.cs
@@ -2,7 +2,7 @@
 {
     public static class UuidHelper
     {
-        public static string Get8BitUuid(this string t)
+        public static string Get4BitUuid(this string t)
         {
             string firstPart = t.Split('-')[0];
             return firstPart.Substring(4, 4);


### PR DESCRIPTION
Had to take another look at BLE to understand my issue with the bit confusion.
I took a heartbeat monitor as an example: most BLE services and characteristics conform to a standard UUID, which only differs in the second 4-bits inside the first 8-bits (a.k.a. low time) of an 128-bit UUID.

Heartbeat Service: `0000[180D]-0000-1000-8000-00805F9B34FB` 
Heartbeat Characteristic: `0000[2A37]-0000-1000-8000-00805F9B34FB`

The part inside `[ ]` is the only thing that differs from the Service and Characteristic.
So I changed the extension method to be `Get4BitUuid` instead of `Get8BitUuid` (which was previously `Get16BitUuid`).