### PR TITLE
Subscribe CommandReceived makes wrong check

### DIFF
--- a/Assets/Scripts/BLE/Commands/SubscribeToCharacteristic.cs
+++ b/Assets/Scripts/BLE/Commands/SubscribeToCharacteristic.cs
@@ -1,7 +1,4 @@
-﻿using Android.BLE.Extension;
-using System;
-
-namespace Android.BLE.Commands
+﻿namespace Android.BLE.Commands
 {
     public class SubscribeToCharacteristic : BleCommand
     {
@@ -54,7 +51,7 @@ namespace Android.BLE.Commands
         {
             if (string.Equals(obj.Command, "CharacteristicValueChanged"))
             {
-                if (obj.Characteristic.Length > 4)
+                if (_customGatt)
                 {
                     if (string.Equals(obj.Device, DeviceAddress) &&
                         string.Equals(obj.Service, DeviceAddress) &&
@@ -67,7 +64,7 @@ namespace Android.BLE.Commands
                 {
                     if (string.Equals(obj.Device, DeviceAddress) &&
                         string.Equals(obj.Service, DeviceAddress) &&
-                        string.Equals(obj.Characteristic, Characteristic.Get8BitUuid()))
+                        string.Equals(obj.Characteristic, "0000" + Characteristic + "-0000-1000-8000-00805f9b34fb"))
                     {
                         OnCharacteristicChanged?.Invoke(obj.GetByteMessage());
                     }

--- a/Assets/Scripts/BLE/Commands/SubscribeToCharacteristic.cs
+++ b/Assets/Scripts/BLE/Commands/SubscribeToCharacteristic.cs
@@ -1,4 +1,6 @@
-﻿namespace Android.BLE.Commands
+﻿using Android.BLE.Extension;
+
+namespace Android.BLE.Commands
 {
     public class SubscribeToCharacteristic : BleCommand
     {
@@ -64,7 +66,7 @@
                 {
                     if (string.Equals(obj.Device, DeviceAddress) &&
                         string.Equals(obj.Service, DeviceAddress) &&
-                        string.Equals(obj.Characteristic, "0000" + Characteristic + "-0000-1000-8000-00805f9b34fb"))
+                        string.Equals(obj.Characteristic.Get8BitUuid(), Characteristic))
                     {
                         OnCharacteristicChanged?.Invoke(obj.GetByteMessage());
                     }


### PR DESCRIPTION
Instead of checking if it's a `_customGatt`, it checks for the length, then proceeds to compare the wrong part of the UUID. What was I thinking?