### PR TITLE
Updated command names to match java library names

### DIFF
--- a/Assets/Scripts/BLE/Commands/ConnectToDevice.cs
+++ b/Assets/Scripts/BLE/Commands/ConnectToDevice.cs
@@ -113,12 +113,12 @@
                             OnConnected?.Invoke(obj.Device);
                         }
                         break;
-                    case "ServiceDiscovered":
+                    case "DiscoveredService":
                         {
                             OnServiceDiscovered?.Invoke(obj.Device, obj.Service);
                             break;
                         }
-                    case "CharacteristicDiscovered":
+                    case "DiscoveredCharacteristic":
                         {
                             OnCharacteristicDiscovered?.Invoke(obj.Device, obj.Service, obj.Characteristic);
                             break;


### PR DESCRIPTION
The name of services and characteristics discovery commands in  `CommandReceived` function in `ConnectToDevice.cs` file are not the same in their names in java library

in java library the commands are called in `discoveredService` functions in `com/velorexe/unityandroidble/UnityAndroidBLE.java` file, that's why the respective callback functions doesn't work in unity