### PR TITLE
Small bug fixes for permission request

### DIFF
--- a/Editor/PostInstallWizard.cs
+++ b/Editor/PostInstallWizard.cs
@@ -148,7 +148,9 @@ namespace Android.BLE.UnityEditor
                 EditorGUILayout.LabelField("AndroidManifest.xml file found",bold);
                 EditorGUILayout.LabelField("Manifest Bluetooth permissions:");
                 foreach(var androidPermission in m_androidPermission){
-                    if((int)PlayerSettings.Android.targetSdkVersion<androidPermission.minSdkVersion){
+                    // if targetSDK set to automatic ( value is 0 ), it's hard to determine the SDK that will be used, use minSDK instead.
+                    var targetSDK = Mathf.Max((int)PlayerSettings.Android.minSdkVersion,(int)PlayerSettings.Android.targetSdkVersion);
+                    if(targetSDK<androidPermission.minSdkVersion){
                         continue;
                     }
                     bool hasPerm = androidPermission.Exists(existingManifestContents);

--- a/Runtime/BLE/AppPermissions.cs
+++ b/Runtime/BLE/AppPermissions.cs
@@ -42,12 +42,25 @@ namespace Android.BLE
         {
             private set;
             get;
+
         }
 
         [SerializeField] bool _checkPermissionsOnStart;
 
         void Awake()
         {
+            // Allow for this script to be added by GameObject.AddComponent 
+            // All UnityEvents are null by default if not Serialized by the Editor
+            if(allPermissionsGrantedEvent==null){
+                allPermissionsGrantedEvent = new UnityEvent();
+            }
+            if(permissionDeniedEvent==null){
+                permissionDeniedEvent = new UnityEvent<string>();                
+            }
+            if(somePermissionsDeniedEvent==null){
+                somePermissionsDeniedEvent = new UnityEvent();                
+            }
+            
             Instance = this;
         }
 

--- a/icons.meta
+++ b/icons.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: c1d1742a26215e2439cfad933d02f5db
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
AppPermission can now be added by using GameObject.AddComponent without throwing errors.

Fixed an issue with AppPermission not checking the right permission name when using Permission.HasUserAuthorizedPermission.


